### PR TITLE
Test on other triggers but only commit on cron

### DIFF
--- a/.github/workflows/update-calendar.yml
+++ b/.github/workflows/update-calendar.yml
@@ -1,6 +1,9 @@
 name: Update calendar
 
 on:
+  push:
+  pull_request:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
 
@@ -22,7 +25,8 @@ jobs:
       run: pipenv install
     - name: Run script
       run: pipenv run update-calendar
-    - uses: stefanzweifel/git-auto-commit-action@v5
+    - if: github.event_name == 'schedule'
+      uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_message: Auto commit - Calendar was updated
 


### PR DESCRIPTION
Allows us to test PRs, and also trigger on demand via the UI if needed.

But only commit changes for cron runs.
